### PR TITLE
Feature: Implementación de funcionalidad para guardar usuarios favoritos

### DIFF
--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/data/datasources/local/AuthToken.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/data/datasources/local/AuthToken.kt
@@ -31,4 +31,35 @@ class AuthToken(
         }
 
     val appToken: String = ar.edu.unlam.mobile.scaffolding.BuildConfig.API_KEY
+
+    private val FAVORITE_USERS_KEY = "FavoriteUsers"
+
+    fun addFavoriteUser(user: User) {
+        val currentList = getFavoriteUsers().toMutableList()
+        if (currentList.none { it.id == user.id }) {
+            currentList.add(user)
+            saveFavoriteUsers(currentList)
+        }
+    }
+
+    fun removeFavoriteUser(userId: Int) {
+        val currentList = getFavoriteUsers().toMutableList()
+        currentList.removeIf { it.id == userId }
+        saveFavoriteUsers(currentList)
+    }
+
+    fun getFavoriteUsers(): List<User> {
+        val json = preferences.getString(FAVORITE_USERS_KEY, null)
+        return if (json != null) {
+            val type = object : TypeToken<List<User>>() {}.type
+            gson.fromJson(json, type)
+        } else {
+            emptyList()
+        }
+    }
+
+    private fun saveFavoriteUsers(users: List<User>) {
+        val json = gson.toJson(users)
+        preferences.edit { putString(FAVORITE_USERS_KEY, json) }
+    }
 }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/data/repositories/UserRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/data/repositories/UserRepository.kt
@@ -63,4 +63,16 @@ class UserRepository(
     override suspend fun clearCachedUser() {
         authToken.cachedUser = null
     }
+
+    override suspend fun saveFavoriteUser(user: User) {
+        authToken.addFavoriteUser(user)
+    }
+
+    override suspend fun getFavoriteUsers(): List<User> {
+        return authToken.getFavoriteUsers()
+    }
+
+    override suspend fun removeFavoriteUser(userId: Int) {
+        authToken.removeFavoriteUser(userId)
+    }
 }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/domain/user/repository/IUserRepository.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/domain/user/repository/IUserRepository.kt
@@ -23,4 +23,10 @@ interface IUserRepository {
     suspend fun saveCachedUser(user: User)
 
     suspend fun clearCachedUser()
+
+    suspend fun saveFavoriteUser(user: User)
+
+    suspend fun getFavoriteUsers(): List<User>
+
+    suspend fun removeFavoriteUser(userId: Int)
 }

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/domain/user/usecases/GetFavoriteUsersUseCase.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/domain/user/usecases/GetFavoriteUsersUseCase.kt
@@ -1,0 +1,10 @@
+package ar.edu.unlam.mobile.scaffolding.domain.user.usecases
+
+import ar.edu.unlam.mobile.scaffolding.domain.user.models.User
+import ar.edu.unlam.mobile.scaffolding.domain.user.repository.IUserRepository
+
+class GetFavoriteUsersUseCase(
+    private val repository: IUserRepository
+) {
+    suspend operator fun invoke(): List<User> = repository.getFavoriteUsers()
+}

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/domain/user/usecases/RemoveFavoriteUserUseCase.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/domain/user/usecases/RemoveFavoriteUserUseCase.kt
@@ -1,0 +1,9 @@
+package ar.edu.unlam.mobile.scaffolding.domain.user.usecases
+
+import ar.edu.unlam.mobile.scaffolding.domain.user.repository.IUserRepository
+
+class RemoveFavoriteUserUseCase(
+    private val repository: IUserRepository
+) {
+    suspend operator fun invoke(userId: Int) = repository.removeFavoriteUser(userId)
+}

--- a/app/src/main/java/ar/edu/unlam/mobile/scaffolding/domain/user/usecases/SaveFavoriteUserUseCase.kt
+++ b/app/src/main/java/ar/edu/unlam/mobile/scaffolding/domain/user/usecases/SaveFavoriteUserUseCase.kt
@@ -1,0 +1,10 @@
+package ar.edu.unlam.mobile.scaffolding.domain.user.usecases
+
+import ar.edu.unlam.mobile.scaffolding.domain.user.models.User
+import ar.edu.unlam.mobile.scaffolding.domain.user.repository.IUserRepository
+
+class SaveFavoriteUserUseCase(
+    private val repository: IUserRepository
+) {
+    suspend operator fun invoke(user: User) = repository.saveFavoriteUser(user)
+}


### PR DESCRIPTION
En esta rama se ha implementado la funcionalidad para manejar usuarios favoritos, incluyendo:

- Modificaciones en el repositorio de usuario (IUserRepository y UserRepository) para soportar agregar, eliminar y obtener   usuarios favoritos.

- Gestión de usuarios favoritos almacenados localmente usando SharedPreferences a través de la clase AuthToken.

- Creación de casos de uso (UseCases) para facilitar la interacción con esta funcionalidad desde la capa de dominio.

Se probó la integración localmente y se verificó que la nueva funcionalidad no afecta el flujo actual.

Solicito revisión y feedback para validar si podemos mergear esta funcionalidad a la rama develop.